### PR TITLE
Fixed incorrect background size on Mobile Safari

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,6 +14,7 @@ $jumbotron_general_image   = get_theme_mod( 'illdy_jumbotron_general_image', esc
 $jumbotron_single_image    = get_theme_mod( 'illdy_jumbotron_enable_featured_image', false );
 $jumbotron_parallax_enable = get_theme_mod( 'illdy_jumbotron_enable_parallax_effect', true );
 $preloader_enable          = get_theme_mod( 'illdy_preloader_enable', 1 );
+$isMobileSafari            = preg_match('/(iPod|iPhone|iPad)/', $_SERVER['HTTP_USER_AGENT']);
 
 $style = '';
 
@@ -36,7 +37,9 @@ if ( get_option( 'show_on_front' ) == 'page' && is_front_page() ) {
 $url = get_theme_mod( 'header_image', get_theme_support( 'custom-header', 'default-image' ) );
 
 // append the parallax effect
-if ( $jumbotron_parallax_enable == true ) {
+if ( $isMobileSafari == true ) {
+	$style .= 'background-attachment: scroll;';
+} elseif ( $jumbotron_parallax_enable == true ) {
 	$style .= 'background-attachment: fixed;';
 }
 


### PR DESCRIPTION
When parallax effect is enabled, the background image does not adhere to the `background-size: cover` property because Apple disabled `background-attachment: fixed;` for scrolling performance.